### PR TITLE
FP16 model precision compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -m MODEL, --model MODEL
                         Inference model name, default yolov7
+  --half                FP16 half-precision export
   --width WIDTH         Inference model input width, default 640
   --height HEIGHT       Inference model input height, default 640
   -u URL, --url URL     Inference server URL, default localhost:8001

--- a/client.py
+++ b/client.py
@@ -271,7 +271,7 @@ if __name__ == '__main__':
 
         inputs = []
         outputs = []
-        if FLAGS:
+        if FLAGS.half:
             inputs.append(grpcclient.InferInput(INPUT_NAMES[0], [1, 3, FLAGS.width, FLAGS.height], "FP16"))
         else:
             inputs.append(grpcclient.InferInput(INPUT_NAMES[0], [1, 3, FLAGS.width, FLAGS.height], "FP32"))


### PR DESCRIPTION
The model deployed on the Triton inference server can have _**FP16**_ precision. Transformations have been added to accommodate this.

Model configuration on Triton Inference Server:
```
{
    "name": "yolov9",
    "platform": "tensorrt_plan",
    "backend": "tensorrt",
    "version_policy": {
        "latest": {
            "num_versions": 1
        }
    },
    "max_batch_size": 8,
    "input": [
        {
            "name": "images",
            "data_type": "TYPE_FP16",
            "dims": [
                3,
                640,
                640
            ],
            "is_shape_tensor": false
        }
    ],
```